### PR TITLE
Fix duplication of UI fields in move_product handler.

### DIFF
--- a/files/ADMIN_FOLDER/includes/ceon_uri_mapping_javascript.php
+++ b/files/ADMIN_FOLDER/includes/ceon_uri_mapping_javascript.php
@@ -244,10 +244,8 @@ window.onload = function(){
 	
 	$ceon_uri_mapping_admin = new CeonURIMappingAdminProductPages();
 
-	$contents_start = 0;
-	if (!empty($GLOBALS['contents'])) {
-		$contents_start = count($GLOBALS['contents']) - 1;
-	}
+	$GLOBALS['contents'] = [];
+
 	$ceon_uri_mapping_admin->addURIMappingFieldsToProductCopyFieldsArray((int) $_GET['pID']);
 	
 	// END CEON URI MAPPING 1 of 1
@@ -255,7 +253,7 @@ window.onload = function(){
 	$ceonUriMappingCopyProduct = '';
 	$contents = $GLOBALS['contents'];
 
-	for ($i = $contents_start, $n = count($contents) - 1; $i < $n; $i++) {
+	for ($i = 0; $i < count($contents); $i++) {
 		$ceonUriMappingCopyProduct .= $contents[$i]['text'];
 	}
 	echo json_encode(/*utf8_encode*/($ceonUriMappingCopyProduct));
@@ -295,10 +293,8 @@ window.onload = function(){
 	
 	$ceon_uri_mapping_admin = new CeonURIMappingAdminProductPages();
 	
-	$contents_start = 0;
-	if (!empty($GLOBALS['contents'])) {
-		$contents_start = count($GLOBALS['contents']) - 1;
-	}
+	$GLOBALS['contents'] = [];
+
 	$ceon_uri_mapping_admin->addURIMappingFieldsToProductMoveFieldsArray((int)$_GET['pID']);
 	
 	// END CEON URI MAPPING 1 of 1
@@ -306,7 +302,7 @@ window.onload = function(){
 	$ceonUriMappingMoveProduct = '';
 	$contents = $GLOBALS['contents'];
 	
-	for ($i = $contents_start, $n = count($contents); $i < $n; $i++) {
+	for ($i = 0; $i < count($contents); $i++) {
 		$ceonUriMappingMoveProduct .= $contents[$i]['text'];
 	}
 	echo json_encode(/*utf8_encode*/($ceonUriMappingMoveProduct));

--- a/files/ADMIN_FOLDER/includes/ceon_uri_mapping_javascript.php
+++ b/files/ADMIN_FOLDER/includes/ceon_uri_mapping_javascript.php
@@ -295,6 +295,10 @@ window.onload = function(){
 	
 	$ceon_uri_mapping_admin = new CeonURIMappingAdminProductPages();
 	
+	$contents_start = 0;
+	if (!empty($GLOBALS['contents'])) {
+		$contents_start = count($GLOBALS['contents']) - 1;
+	}
 	$ceon_uri_mapping_admin->addURIMappingFieldsToProductMoveFieldsArray((int)$_GET['pID']);
 	
 	// END CEON URI MAPPING 1 of 1
@@ -302,7 +306,7 @@ window.onload = function(){
 	$ceonUriMappingMoveProduct = '';
 	$contents = $GLOBALS['contents'];
 	
-	for ($i = 0, $n = count($contents); $i < $n; $i++) {
+	for ($i = $contents_start, $n = count($contents); $i < $n; $i++) {
 		$ceonUriMappingMoveProduct .= $contents[$i]['text'];
 	}
 	echo json_encode(/*utf8_encode*/($ceonUriMappingMoveProduct));


### PR DESCRIPTION
Code was missing the trick used in 'copy_product' to only output rows from $content that had not already been output.