### PR TITLE
Admin, Manufacturer, Insert: fix for duplicate URI field

### DIFF
--- a/files/ADMIN_FOLDER/includes/ceon_uri_mapping_javascript.php
+++ b/files/ADMIN_FOLDER/includes/ceon_uri_mapping_javascript.php
@@ -104,9 +104,9 @@ window.onload = function(){
 if (defined('FILENAME_MANUFACTURERS') && $_SERVER['SCRIPT_NAME'] == DIR_WS_ADMIN . (!strstr(FILENAME_MANUFACTURERS, '.php') ? FILENAME_MANUFACTURERS . '.php' : FILENAME_MANUFACTURERS) && isset($_GET['action']) && $_GET['action'] == 'edit') {
 	$ceon_class_name = 'row infoBoxContent';
 ?>
-	<script title="ceon_uri_mapping_javascript(<?php echo __LINE__; ?>)">
+	<script title="ceon_uri_mapping_javascript(<?= __LINE__ ?>)">
 window.onload = function(){
-	var ceonUriMappingGeneratedURI = document.createElement("div");
+	let ceonUriMappingGeneratedURI = document.createElement("div");
 	ceonUriMappingGeneratedURI.setAttribute("class", "<?php echo $ceon_class_name; ?>");
 	ceonUriMappingGeneratedURI.innerHTML = <?php
 	require_once(DIR_WS_CLASSES . 'class.CeonURIMappingAdminManufacturerPages.php');
@@ -136,44 +136,30 @@ window.onload = function(){
 if (defined('FILENAME_MANUFACTURERS') && $_SERVER['SCRIPT_NAME'] == DIR_WS_ADMIN . (!strstr(FILENAME_MANUFACTURERS, '.php') ? FILENAME_MANUFACTURERS . '.php' : FILENAME_MANUFACTURERS) && isset($_GET['action']) && $_GET['action'] == 'new') {
 	$ceon_class_name = 'row infoBoxContent';
 ?>
-	<script title="ceon_uri_mapping_javascript(<?php echo __LINE__; ?>)">
+	<script title="ceon_uri_mapping_javascript(<?= __LINE__ ?>)">
 window.onload = function(){
-	var ceonUriMappingGeneratedURI = document.createElement("div");
+	let ceonUriMappingGeneratedURI = document.createElement("div");
 	ceonUriMappingGeneratedURI.setAttribute("class", "<?php echo $ceon_class_name; ?>");
-	
 	ceonUriMappingGeneratedURI.innerHTML = <?php
-
-	$languages = zen_get_languages();
-
-	// BEGIN CEON URI MAPPING 3 of 4
-	require_once(DIR_WS_CLASSES . 'class.CeonURIMappingAdminManufacturerPages.php');
-	
+    $languages = zen_get_languages();
+    require_once(DIR_WS_CLASSES . 'class.CeonURIMappingAdminManufacturerPages.php');
 	$ceon_uri_mapping_admin = new CeonURIMappingAdminManufacturerPages();
-	
+    $GLOBALS['contents'] = [];
 	$ceon_uri_mapping_admin->addURIMappingFieldsToAddManufacturerFieldsArray();
-	
-	// END CEON URI MAPPING 3 of 4
-	
-	$text_str = '';
-	foreach ($GLOBALS['contents'] as $key => $value) {
-		$text_str .= $value['text'];
-	}
-	
-	echo json_encode(/*utf8_encode*/($text_str));
-	// END CEON URI MAPPING 3 of 3
-	 ?>;
-	
-	var classList = document.getElementsByClassName("<?php echo $ceon_class_name; ?>");
-	var place = classList[classList.length - 1];
-	
+    $ceonUriMappingDiv = '';
+    $contents = $GLOBALS['contents'];
+    for ($i = 0; $i < count($contents); $i++) {
+        $ceonUriMappingDiv .= $contents[$i]['text'];
+    }
+	echo json_encode($ceonUriMappingDiv);
+	?>;
+	let classList = document.getElementsByClassName("<?=$ceon_class_name; ?>");
+	let place = classList[classList.length - 1];
 	if (!classList.length) {
-		var formList = document.forms;
+        let formList = document.forms;
 		place = formList[formList.length - 1][formList[formList.length - 1].length - 1];
 	}
-	
 	place.parentElement.insertBefore(ceonUriMappingGeneratedURI, place);
-
-//   ?>;
 };
 	</script>
 <?php }

--- a/files/ADMIN_FOLDER/includes/classes/class.CeonURIMappingAdminManufacturerPages.php
+++ b/files/ADMIN_FOLDER/includes/classes/class.CeonURIMappingAdminManufacturerPages.php
@@ -41,7 +41,7 @@ require_once(DIR_FS_CATALOG . DIR_WS_CLASSES . 'class.CeonURIMappingAdminManufac
 class CeonURIMappingAdminManufacturerPages extends CeonURIMappingAdminManufacturers
 {
 	// {{{ properties
-		
+
 	/**
 	 * Maintains a copy of the current URI mappings entered/generated for the Manufacturer.
 	 *
@@ -49,7 +49,7 @@ class CeonURIMappingAdminManufacturerPages extends CeonURIMappingAdminManufactur
 	 * @access  protected
 	 */
 	protected $_uri_mappings = array();
-	
+
 	/**
 	 * Maintains a copy of any previous URI mappings for the Manufacturer.
 	 *
@@ -57,7 +57,7 @@ class CeonURIMappingAdminManufacturerPages extends CeonURIMappingAdminManufactur
 	 * @access  protected
 	 */
 	protected $_prev_uri_mappings = array();
-	
+
 	/**
 	 * Flag indicates whether or not auto-generation of URI mappings has been selected for the Manufacturer.
 	 *
@@ -65,7 +65,7 @@ class CeonURIMappingAdminManufacturerPages extends CeonURIMappingAdminManufactur
 	 * @access  protected
 	 */
 	protected $_uri_mapping_autogen = false;
-	
+
 	/**
 	 * Maintains a list of any URI mappings for the Manufacturer which clash with existing mappings.
 	 *
@@ -73,35 +73,35 @@ class CeonURIMappingAdminManufacturerPages extends CeonURIMappingAdminManufactur
 	 * @access  protected
 	 */
 	protected $_clashing_mappings = array();
-	
+
 	// }}}
-	
-	
+
+
 	// {{{ Class Constructor
-	
+
 	/**
 	 * Creates a new instance of the CeonURIMappingAdminManufacturerPages class.
-	 * 
+	 *
 	 * @access  public
 	 */
 	public function __construct()
 	{
 		// Load the language definition file for the current language
 		@include_once(DIR_WS_LANGUAGES . $_SESSION['language'] . '/' . 'ceon_uri_mapping_manufacturer_pages.php');
-		
+
 		if (!defined('CEON_URI_MAPPING_TEXT_MANUFACTURERS_URI') && $_SESSION['language'] != 'english') {
 			// Fall back to english language file
 			@include_once(DIR_WS_LANGUAGES . 'english/' . 'ceon_uri_mapping_manufacturer_pages.php');
 		}
-		
+
 		parent::__construct();
 	}
-	
+
 	// }}}
-	
-	
+
+
 	// {{{ insertSaveHandler()
-	
+
 	/**
 	 * Handles the Ceon URI Mapping functionality when a manufacturer is being inserted or updated.
 	 *
@@ -113,41 +113,41 @@ class CeonURIMappingAdminManufacturerPages extends CeonURIMappingAdminManufactur
 	public function insertSaveHandler($manufacturer_id, $manufacturer_name)
 	{
 		global $messageStack;
-		
+
 		$uri_mapping_autogen = (isset($_POST['uri-mapping-autogen']) ? true : false);
-		
+
 		$languages = zen_get_languages();
-		
+
 		for ($i = 0, $n = count($languages); $i < $n; $i++) {
 			$prev_uri_mapping = trim($_POST['prev-uri-mappings'][$languages[$i]['id']]);
-			
+
 			// Auto-generate the URI if requested
 			if ($uri_mapping_autogen) {
 				$uri_mapping = $this->autogenManufacturerURIMapping($manufacturer_id, $manufacturer_name,
 					$languages[$i]['code'], $languages[$i]['id']);
-				
+
 				if ($uri_mapping == CEON_URI_MAPPING_GENERATION_ATTEMPT_FOR_MANUFACTURER_WITH_NO_NAME) {
 					// Can't generate the URI because of missing "uniqueness" data
 					$failure_message = sprintf(CEON_URI_MAPPING_TEXT_ERROR_AUTOGENERATION_MANUFACTURER_HAS_NO_NAME,
 						ucwords($languages[$i]['name']));
-					
+
 					$messageStack->add_session($failure_message, 'error');
-					
+
 					continue;
 				}
 			} else {
 				$uri_mapping = $_POST['uri-mappings'][$languages[$i]['id']];
 			}
-			
+
 			if (strlen($uri_mapping) > 1) {
 				// Make sure URI mapping is relative to root of site and does not have a trailing slash or any ~
 				// illegal characters
 				$uri_mapping = $this->_cleanUpURIMapping($uri_mapping);
 			}
-			
+
 			$insert_uri_mapping = false;
 			$update_uri_mapping = false;
-			
+
 			if ($uri_mapping != '') {
 				// Check if the URI mapping is being updated or does not yet exist
 				if ($prev_uri_mapping == '') {
@@ -156,23 +156,23 @@ class CeonURIMappingAdminManufacturerPages extends CeonURIMappingAdminManufactur
 					$update_uri_mapping = true;
 				}
 			}
-			
+
 			$query_string_parameters = 'manufacturers_id=' . (int) $manufacturer_id;
-			
+
 			if ($insert_uri_mapping || $update_uri_mapping) {
 				if ($update_uri_mapping) {
 					// Consign previous mapping to the history, so old URI mapping isn't broken
 					$this->makeURIMappingHistorical($prev_uri_mapping, $languages[$i]['id']);
 				}
-				
+
 				// Add the new URI mapping
 				$uri = $uri_mapping;
-				
+
 				$main_page = FILENAME_DEFAULT;
-				
+
 				$mapping_added =
 					$this->addURIMapping($uri, $languages[$i]['id'], $main_page, $query_string_parameters);
-				
+
 				if ($mapping_added == CEON_URI_MAPPING_ADD_MAPPING_SUCCESS) {
 					if ($insert_uri_mapping) {
 						$success_message = sprintf(CEON_URI_MAPPING_TEXT_MANUFACTURER_MAPPING_ADDED,
@@ -183,15 +183,15 @@ class CeonURIMappingAdminManufacturerPages extends CeonURIMappingAdminManufactur
 							ucwords($languages[$i]['name']),
 							'<a href="' . HTTP_SERVER . $uri . '" target="_blank">' . $uri . '</a>');
 					}
-					
+
 					$messageStack->add_session($success_message, 'success');
-					
+
 				} else {
 					if ($mapping_added == CEON_URI_MAPPING_ADD_MAPPING_ERROR_MAPPING_EXISTS) {
 						$failure_message = sprintf(CEON_URI_MAPPING_TEXT_ERROR_ADD_MAPPING_EXISTS,
 							ucwords($languages[$i]['name']),
 							'<a href="' . HTTP_SERVER . $uri . '" target="_blank">' . $uri . '</a>');
-						
+
 					} else if ($mapping_added == CEON_URI_MAPPING_ADD_MAPPING_ERROR_DATA_ERROR) {
 						$failure_message = sprintf(CEON_URI_MAPPING_TEXT_ERROR_ADD_MAPPING_DATA,
 							ucwords($languages[$i]['name']), $uri);
@@ -199,26 +199,26 @@ class CeonURIMappingAdminManufacturerPages extends CeonURIMappingAdminManufactur
 						$failure_message = sprintf(CEON_URI_MAPPING_TEXT_ERROR_ADD_MAPPING_DB,
 							ucwords($languages[$i]['name']), $uri);
 					}
-					
+
 					$messageStack->add_session($failure_message, 'error');
 				}
 			} else if ($prev_uri_mapping != '' && $uri_mapping == '') {
 				// No URI mapping, consign existing mapping to the history, so old URI mapping isn't broken
 				$this->makeURIMappingHistorical($prev_uri_mapping, $languages[$i]['id']);
-				
+
 				$success_message = sprintf(CEON_URI_MAPPING_TEXT_MANUFACTURER_MAPPING_MADE_HISTORICAL,
 					ucwords($languages[$i]['name']));
-				
+
 				$messageStack->add_session($success_message, 'caution');
 			}
 		}
 	}
-	
+
 	// }}}
-	
-	
+
+
 	// {{{ deleteConfirmHandler()
-	
+
 	/**
 	 * Handles the Ceon URI Mapping functionality when a Manufacturer is being deleted.
 	 *
@@ -229,20 +229,20 @@ class CeonURIMappingAdminManufacturerPages extends CeonURIMappingAdminManufactur
 	public function deleteConfirmHandler($manufacturer_id)
 	{
 		$query_string_parameters = 'manufacturers_id=' . (int) $manufacturer_id;
-		
+
 		$selections = array(
 			'main_page' => FILENAME_DEFAULT,
 			'query_string_parameters' => $query_string_parameters
 			);
-		
+
 		$this->deleteURIMappings($selections);
 	}
-	
+
 	// }}}
-	
-	
+
+
 	// {{{ addURIMappingFieldsToAddManufacturerFieldsArray()
-	
+
 	/**
 	 * Adds the fields necessary for the Ceon URI Mapping options to the list of add manufacturer fields, accessing
 	 * the list of add manufacturer fields directly, through a global variable.
@@ -253,20 +253,20 @@ class CeonURIMappingAdminManufacturerPages extends CeonURIMappingAdminManufactur
 	public function addURIMappingFieldsToAddManufacturerFieldsArray()
 	{
 		global $contents;
-		
+
 		// New manufacturer doesn't have any previous URI mappings
 		$prev_uri_mappings = array();
-		
+
 		$uri_mapping_input_fields = $this->buildManufacturerURIMappingFormFields($prev_uri_mappings);
-		
+
 		$contents[] = array('text' => $uri_mapping_input_fields);
 	}
-	
+
 	// }}}
-	
-	
+
+
 	// {{{ addURIMappingFieldsToEditManufacturerFieldsArray()
-	
+
 	/**
 	 * Adds the fields necessary for the Ceon URI Mapping options to the list of edit manufacturer fields,
 	 * accessing the list of edit manufacturer fields directly, through a global variable.
@@ -278,42 +278,42 @@ class CeonURIMappingAdminManufacturerPages extends CeonURIMappingAdminManufactur
 	public function addURIMappingFieldsToEditManufacturerFieldsArray($manufacturer_id)
 	{
 		global $contents;
-		
+
 		// Get any current manufacturer mappings from the database, up to one for each language
 		$prev_uri_mappings = array();
-		
+
 		$columns_to_retrieve = array(
 			'language_id',
 			'uri'
 			);
-		
+
 		$query_string_parameters = 'manufacturers_id=' . (int) $manufacturer_id;
-		
+
 		$selections = array(
 			'main_page' => FILENAME_DEFAULT,
 			'query_string_parameters' => $query_string_parameters,
 			'current_uri' => 1
 			);
-		
+
 		$prev_uri_mappings_result = $this->getURIMappingsResultset($columns_to_retrieve, $selections);
-		
+
 		while (!$prev_uri_mappings_result->EOF) {
 			$prev_uri_mappings[$prev_uri_mappings_result->fields['language_id']] =
 				$prev_uri_mappings_result->fields['uri'];
-			
+
 			$prev_uri_mappings_result->MoveNext();
 		}
-		
+
 		$uri_mapping_input_fields = $this->buildManufacturerURIMappingFields($prev_uri_mappings);
-		
+
 		$contents[] = array('text' => $uri_mapping_input_fields);
 	}
-	
+
 	// }}}
-	
-	
+
+
 	// {{{ addURIMappingFieldsToEditManufacturerFieldsFormArray()
-	
+
 	/**
 	 * Adds the fields necessary for the Ceon URI Mapping options to the list of edit manufacturer fields,
 	 * accessing the list of edit manufacturer fields directly, through a global variable.
@@ -328,39 +328,39 @@ class CeonURIMappingAdminManufacturerPages extends CeonURIMappingAdminManufactur
 		
 		// Get any current manufacturer mappings from the database, up to one for each language
 		$prev_uri_mappings = array();
-		
+
 		$columns_to_retrieve = array(
 			'language_id',
 			'uri'
 			);
-		
+
 		$query_string_parameters = 'manufacturers_id=' . (int) $manufacturer_id;
-		
+
 		$selections = array(
 			'main_page' => FILENAME_DEFAULT,
 			'query_string_parameters' => $query_string_parameters,
 			'current_uri' => 1
 			);
-		
+
 		$prev_uri_mappings_result = $this->getURIMappingsResultset($columns_to_retrieve, $selections);
-		
+
 		while (!$prev_uri_mappings_result->EOF) {
 			$prev_uri_mappings[$prev_uri_mappings_result->fields['language_id']] =
 				$prev_uri_mappings_result->fields['uri'];
-			
+
 			$prev_uri_mappings_result->MoveNext();
 		}
-		
+
 		$uri_mapping_input_fields = $this->buildManufacturerURIMappingFormFields($prev_uri_mappings);
-		
+
 		$contents[] = array('text' => $uri_mapping_input_fields);
 	}
-	
+
 	// }}}
-	
-	
+
+
 	// {{{ buildManufacturerURIMappingFields()
-	
+
 	/**
 	 * Builds the input fields for adding/editing URI mappings for manufacturers.
 	 *
@@ -371,55 +371,55 @@ class CeonURIMappingAdminManufacturerPages extends CeonURIMappingAdminManufactur
 	public function buildManufacturerURIMappingFields($prev_uri_mappings)
 	{
 		global $languages;
-		
+
 		$num_prev_uri_mappings = count($prev_uri_mappings);
-		
+
 		$num_languages = count($languages);
-		
+
 		$uri_mapping_input_fields = zen_draw_separator('pixel_black.gif', '100%', '2');
-		
+
 		$uri_mapping_input_fields .= '<table border="0" cellspacing="0" cellpadding="0">' . "\n\t";
 		$uri_mapping_input_fields .= '<tr>' . "\n\t\t" .
 			'<td rowspan="2" class="main" valign="top" style="width: 10em; padding-top: 0.5em;">';
-		
+
 		$uri_mapping_input_fields .= CEON_URI_MAPPING_TEXT_MANUFACTURER_URI . '</td>' . "\n\t\t" .
 			'<td class="main" style="padding-top: 0.5em; padding-bottom: 0;">' . "\n";
-		
+
 		for ($i = 0, $n = count($languages); $i < $n; $i++) {
 			$uri_mapping_input_fields .= "<p>";
-			
+
 			if (!isset($prev_uri_mappings[$languages[$i]['id']])) {
 				$prev_uri_mappings[$languages[$i]['id']] = '';
 			}
-			
+
 			$uri_mapping_input_fields .= zen_draw_hidden_field('prev-uri-mappings[' . $languages[$i]['id'] . ']',
 				$prev_uri_mappings[$languages[$i]['id']]);
-			
+
 			$uri_mapping_input_fields .= zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] .
 				'/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' .
 				zen_draw_input_field('uri-mappings[' . $languages[$i]['id'] . ']',
 				$prev_uri_mappings[$languages[$i]['id']], 'size="60"');
-			
+
 			$uri_mapping_input_fields .= "</p>\n";
 		}
-		
+
 		$uri_mapping_input_fields .= '</td>' . "\n\t</tr>\n\t<tr>\n\t\t" .
 			'<td class="main" style="padding-top: 1em; padding-bottom: 0.5em;">' . "\n";
-		
+
 		$uri_mapping_input_fields .= "<p>";
-		
+
 		if ($this->_autogenEnabled()) {
 			if ($num_languages == 1) {
 				$autogen_message = CEON_URI_MAPPING_TEXT_MANUFACTURER_URI_AUTOGEN;
 			} else {
 				$autogen_message = CEON_URI_MAPPING_TEXT_MANUFACTURER_URIS_AUTOGEN;
 			}
-			
+
 			if ($num_prev_uri_mappings == 0) {
 				$autogen_selected = true;
 			} else {
 				$autogen_selected = false;
-				
+
 				if ($num_prev_uri_mappings == 1) {
 					$autogen_message .= '<br />' . CEON_URI_MAPPING_TEXT_URI_AUTOGEN_ONE_EXISTING_MAPPING;
 				} else if ($num_prev_uri_mappings == $num_languages) {
@@ -428,27 +428,27 @@ class CeonURIMappingAdminManufacturerPages extends CeonURIMappingAdminManufactur
 					$autogen_message .= '<br />' . CEON_URI_MAPPING_TEXT_URI_AUTOGEN_SOME_EXISTING_MAPPINGS;
 				}
 			}
-			
+
 			$uri_mapping_input_fields .=
 				zen_draw_checkbox_field('uri-mapping-autogen', '1', $autogen_selected) . ' ' . $autogen_message;
 		} else {
 			$uri_mapping_input_fields .= CEON_URI_MAPPING_TEXT_URI_AUTOGEN_DISABLED;
 		}
-		
+
 		$uri_mapping_input_fields .= "</p>";
-		
+
 		$uri_mapping_input_fields .= "\n\t\t</td>\n\t</tr>\n</table>\n";
-		
+
 		$uri_mapping_input_fields .= zen_draw_separator('pixel_black.gif', '100%', '2');
-		
+
 		return $uri_mapping_input_fields;
 	}
-	
+
 	/// }}}
-	
-	
+
+
 	// {{{ buildManufacturerURIMappingFormFields()
-	
+
 	/**
 	 * Builds the input fields for adding/editing URI mappings for manufacturers.
 	 *
@@ -459,57 +459,57 @@ class CeonURIMappingAdminManufacturerPages extends CeonURIMappingAdminManufactur
 	public function buildManufacturerURIMappingFormFields($prev_uri_mappings)
 	{
 		global $languages;
-		
+
 		$num_prev_uri_mappings = count($prev_uri_mappings);
-		
+
 		$num_languages = count($languages);
-		
+
 		$uri_mapping_input_fields = '<br>';
-		
+
 		$uri_mapping_input_fields .= zen_draw_separator('pixel_black.gif', '100%', '2');
-		
+
 /*		$uri_mapping_input_fields .= '<table border="0" cellspacing="0" cellpadding="0">' . "\n\t";
 		$uri_mapping_input_fields .= '<tr>' . "\n\t\t" .
 			'<td rowspan="2" class="main" valign="top" style="width: 10em; padding-top: 0.5em;">';*/
-		
+
 		$uri_mapping_input_fields .= CEON_URI_MAPPING_TEXT_MANUFACTURER_URI /*. '</td>' . "\n\t\t" .
 			'<td class="main" style="padding-top: 0.5em; padding-bottom: 0;">'*/ . "\n";
-		
+
 		for ($i = 0, $n = sizeof($languages); $i < $n; $i++) {
 			$uri_mapping_input_fields .= "<p>";
-			
+
 			if (!isset($prev_uri_mappings[$languages[$i]['id']])) {
 				$prev_uri_mappings[$languages[$i]['id']] = '';
 			}
-			
+
 			$uri_mapping_input_fields .= zen_draw_hidden_field('prev-uri-mappings[' . $languages[$i]['id'] . ']',
 				$prev_uri_mappings[$languages[$i]['id']]);
-			
+
 			$uri_mapping_input_fields .= zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] .
 				'/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' .
 				zen_draw_input_field('uri-mappings[' . $languages[$i]['id'] . ']',
 				$prev_uri_mappings[$languages[$i]['id']], 'class="form-control" size="60"');
-			
+
 			$uri_mapping_input_fields .= "</p>\n";
 		}
-		
+
 		$uri_mapping_input_fields .= /*'</td>' . "\n\t</tr>\n\t<tr>\n\t\t" .
 			'<td class="main" style="padding-top: 1em; padding-bottom: 0.5em;">' .*/ "\n";
-		
+
 		$uri_mapping_input_fields .= "<p>";
-		
+
 		if ($this->_autogenEnabled()) {
 			if ($num_languages == 1) {
 				$autogen_message = CEON_URI_MAPPING_TEXT_MANUFACTURER_URI_AUTOGEN;
 			} else {
 				$autogen_message = CEON_URI_MAPPING_TEXT_MANUFACTURER_URIS_AUTOGEN;
 			}
-			
+
 			if ($num_prev_uri_mappings == 0) {
 				$autogen_selected = true;
 			} else {
 				$autogen_selected = false;
-				
+
 				if ($num_prev_uri_mappings == 1) {
 					$autogen_message .= '<br />' . CEON_URI_MAPPING_TEXT_URI_AUTOGEN_ONE_EXISTING_MAPPING;
 				} else if ($num_prev_uri_mappings == $num_languages) {
@@ -518,22 +518,22 @@ class CeonURIMappingAdminManufacturerPages extends CeonURIMappingAdminManufactur
 					$autogen_message .= '<br />' . CEON_URI_MAPPING_TEXT_URI_AUTOGEN_SOME_EXISTING_MAPPINGS;
 				}
 			}
-			
+
 			$uri_mapping_input_fields .=
 				zen_draw_checkbox_field('uri-mapping-autogen', '1', $autogen_selected) . ' ' . $autogen_message;
 		} else {
 			$uri_mapping_input_fields .= CEON_URI_MAPPING_TEXT_URI_AUTOGEN_DISABLED;
 		}
-		
+
 		$uri_mapping_input_fields .= "</p>";
-		
+
 //		$uri_mapping_input_fields .= "\n\t\t</td>\n\t</tr>\n</table>\n";
-		
+
 		$uri_mapping_input_fields .= zen_draw_separator('pixel_black.gif', '100%', '2');
-		
+
 		return $uri_mapping_input_fields;
 	}
-	
+
 	/// }}}
 }
 

--- a/files/ADMIN_FOLDER/includes/classes/class.CeonURIMappingAdminManufacturerPages.php
+++ b/files/ADMIN_FOLDER/includes/classes/class.CeonURIMappingAdminManufacturerPages.php
@@ -257,7 +257,7 @@ class CeonURIMappingAdminManufacturerPages extends CeonURIMappingAdminManufactur
 		// New manufacturer doesn't have any previous URI mappings
 		$prev_uri_mappings = array();
 		
-		$uri_mapping_input_fields = $this->buildManufacturerURIMappingFields($prev_uri_mappings);
+		$uri_mapping_input_fields = $this->buildManufacturerURIMappingFormFields($prev_uri_mappings);
 		
 		$contents[] = array('text' => $uri_mapping_input_fields);
 	}


### PR DESCRIPTION
Noting that
buildManufacturerURIMappingFormFields
and 
buildManufacturerURIMappingFields
are functionally identical, but the latter (which was previously in use) uses a table structure and is probably legacy/can be removed.