### PR TITLE
Fix bug with FILENAME_TELL_A_FRIEND

### DIFF
--- a/files/ADMIN_FOLDER/includes/classes/class.CeonURIMappingAdminProductPages.php
+++ b/files/ADMIN_FOLDER/includes/classes/class.CeonURIMappingAdminProductPages.php
@@ -879,9 +879,11 @@ class CeonURIMappingAdminProductPages extends CeonURIMappingAdminProducts
 			'product_reviews',
 			'product_reviews_info',
 			'product_reviews_write',
-			'tell_a_friend',
 			'ask_a_question'
         ];
+
+        if(defined("FILENAME_TELL_A_FRIEND"))
+			$page_types[] = 'tell_a_friend';
 
 		$page_types_to_manage = [];
 


### PR DESCRIPTION
Check for FILENAME_TELL_A_FRIEND being defined before adding it to the list since it's been removed in recent ZC versions.

Fixes bug 
````
PHP Fatal error:  Uncaught Error: Undefined constant "FILENAME_TELL_A_FRIEND" in /home/sites/website/www/admin/includes/classes/class.CeonURIMappingAdminProductPages.php:997
Stack trace:
#0 /home/sites/website/www/admin/includes/classes/class.CeonURIMappingAdminProductPages.php(997): constant('FILENAME_TELL_A...')
#1 /home/sites/website/www/admin/includes/init_includes/init_ceon_product_collect_info.php(85): CeonURIMappingAdminProductPages->updateProductHandler(53382, 'product')
#2 /home/sites/website/www/includes/autoload_func.php(40): require_once('/home/sites/new...')
#3 /home/sites/website/www/admin/includes/application_top.php(40): require('/home/sites/new...')
#4 /home/sites/website/www/admin/category_product_listing.php(8): require('/home/sites/new...')
#5 /home/sites/website/www/admin/index.php(16): require('/home/sites/new...')
#6 {main}
  thrown in /home/sites/website/www/admin/includes/classes/class.CeonURIMappingAdminProductPages.php on line 997

Request URI: /admin/index.php?cmd=category_product_listing&cPath=569&pID=53382, IP address: x.x.x.x
--> PHP Fatal error: Uncaught Error: Undefined constant "FILENAME_TELL_A_FRIEND" in /home/sites/website/www/admin/includes/classes/class.CeonURIMappingAdminProductPages.php:997
Stack trace:
#0 /home/sites/website/www/admin/includes/classes/class.CeonURIMappingAdminProductPages.php(997): constant('FILENAME_TELL_A...')
#1 /home/sites/website/www/admin/includes/init_includes/init_ceon_product_collect_info.php(85): CeonURIMappingAdminProductPages->updateProductHandler(53382, 'product')
#2 /home/sites/website/www/includes/autoload_func.php(40): require_once('/home/sites/new...')
#3 /home/sites/website/www/admin/includes/application_top.php(40): require('/home/sites/new...')
#4 /home/sites/website/www/admin/category_product_listing.php(8): require('/home/sites/new...')
#5 /home/sites/website/www/admin/index.php(16): require('/home/sites/new...')
#6 {main}
  thrown in /home/sites/website/www/admin/includes/classes/class.CeonURIMappingAdminProductPages.php on line 997.

Request URI: /admin/index.php?cmd=category_product_listing&cPath=569&pID=53382, IP address: x.x.x.x
--> PHP Fatal error: Uncaught Error: Undefined constant "FILENAME_TELL_A_FRIEND" in /home/sites/website/www/admin/includes/classes/class.CeonURIMappingAdminProductPages.php:997
Stack trace:
#0 /home/sites/website/www/admin/includes/classes/class.CeonURIMappingAdminProductPages.php(997): constant('FILENAME_TELL_A...')
#1 /home/sites/website/www/admin/includes/init_includes/init_ceon_product_collect_info.php(85): CeonURIMappingAdminProductPages->updateProductHandler(53382, 'product')
#2 /home/sites/website/www/includes/autoload_func.php(40): require_once('/home/sites/new...')
#3 /home/sites/website/www/admin/includes/application_top.php(40): require('/home/sites/new...')
#4 /home/sites/website/www/admin/category_product_listing.php(8): require('/home/sites/new...')
#5 /home/sites/website/www/admin/index.php(16): require('/home/sites/new...')
#6 {main}
  thrown in /home/sites/website/www/admin/includes/classes/class.CeonURIMappingAdminProductPages.php on line 997.
````